### PR TITLE
reworked RecipeManagerMixin to work with KubeJS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,6 +140,14 @@ allprojects {
         maven {
             url = "https://maven.blamejared.com/"
         }
+        maven {
+            // saps.dev Maven (KubeJS and Rhino)
+            url = uri("https://maven.saps.dev/releases")
+            content {
+                includeGroup("dev.latvian.mods")
+                includeGroup("dev.latvian.apps")
+            }
+        }
 
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,11 +34,11 @@ parchment_version = 1.20.6:2024.06.16
 fabric_loader_version = 0.15.11
 fabric_api_version = 0.100.3+1.21
 
-neo_version = 21.0.143
+neo_version = 21.0.148
 neo_version_range = [4,)
 loader_version_range = [4,)
 
 # Other deps
-moonlight_version = 1.21-2.14.18a
+moonlight_version = 1.21-2.14.19a
 moonlight_version_range = 1.21-2.14.0
 

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -12,6 +12,11 @@ architectury {
 
 loom {
     accessWidenerPath = project(":common").loom.accessWidenerPath
+    runs {
+        configureEach {
+            vmArg "-Dmixin.debug.export=true"
+        }
+    }
 }
 
 configurations {
@@ -101,12 +106,13 @@ dependencies {
 
     modCompileOnly("curse.maven:repurposed-structures-368293:4823487")
     modCompileOnly("curse.maven:framedblocks-441647:5143589")
-    modCompileOnly("cy.jdkdigital.productivelib:productivelib-1.20.1-0.0.4")
-    modCompileOnly("cy.jdkdigital.productivetrees:productivetrees-1.20.1-0.2.2")
+//    modCompileOnly("cy.jdkdigital.productivelib:productivelib-1.20.1-0.0.4")
+//    modCompileOnly("cy.jdkdigital.productivetrees:productivetrees-1.20.1-0.2.2")
 
     modImplementation("curse.maven:emi-580555:5704405")
-    modImplementation("curse.maven:kubejs-238086:5810100")
-
+    modRuntimeOnly "dev.latvian.mods:kubejs-neoforge:2101.7.1-build.181"
+    modRuntimeOnly "dev.latvian.mods:rhino:2101.2.5-build.54"
+    forgeRuntimeLibrary "dev.latvian.apps:tiny-java-server:1.0.0-build.6"
     //modImplementation("curse.maven:jei-238222:5603591")
 
 

--- a/neoforge/src/main/java/net/mehvahdjukaar/sawmill/mixins/neoforge/RecipeManagerMixin.java
+++ b/neoforge/src/main/java/net/mehvahdjukaar/sawmill/mixins/neoforge/RecipeManagerMixin.java
@@ -2,11 +2,8 @@ package net.mehvahdjukaar.sawmill.mixins.neoforge;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
 import com.google.gson.JsonElement;
-import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
-import com.llamalad7.mixinextras.sugar.Local;
-import com.llamalad7.mixinextras.sugar.Share;
-import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import net.mehvahdjukaar.sawmill.SawmillRecipeGenerator;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.ResourceManager;
@@ -14,9 +11,8 @@ import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.world.item.crafting.RecipeHolder;
 import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.item.crafting.RecipeType;
-import net.minecraft.world.level.block.FireBlock;
-import net.neoforged.neoforge.common.crafting.IngredientType;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -25,28 +21,22 @@ import java.util.Map;
 
 @Mixin(RecipeManager.class)
 public class RecipeManagerMixin {
+    @Shadow
+    private Map<ResourceLocation, RecipeHolder<?>> byName;
 
+    @Shadow
+    private Multimap<RecipeType<?>, RecipeHolder<?>> byType;
 
-    @ModifyExpressionValue(method = "apply(Ljava/util/Map;Lnet/minecraft/server/packs/resources/ResourceManager;Lnet/minecraft/util/profiling/ProfilerFiller;)V",
-            at = @At(value = "INVOKE", target = "Lcom/google/common/collect/ImmutableMap;builder()Lcom/google/common/collect/ImmutableMap$Builder;"))
-    public ImmutableMap.Builder<ResourceLocation, RecipeHolder<?>> sawmill$whyCantICaptureThatLocal(ImmutableMap.Builder<ResourceLocation, RecipeHolder<?>> original,
-                                                                                                    @Share("byName") LocalRef<ImmutableMap.Builder<ResourceLocation, RecipeHolder<?>>> byName) {
-        byName.set(original);
-        return original;
+    @Inject(method = "apply(Ljava/util/Map;Lnet/minecraft/server/packs/resources/ResourceManager;Lnet/minecraft/util/profiling/ProfilerFiller;)V", at = @At(value = "INVOKE_ASSIGN", target = "Lcom/google/common/collect/ImmutableMap$Builder;build()Lcom/google/common/collect/ImmutableMap;", shift = At.Shift.AFTER))
+    public void sawmill$addRecipes(Map<ResourceLocation, JsonElement> object, ResourceManager resourceManager, ProfilerFiller profiler, CallbackInfo ci) {
+        ImmutableMap.Builder<ResourceLocation, RecipeHolder<?>> byNameCopy = ImmutableMap.builder();
+        ImmutableMultimap.Builder<RecipeType<?>, RecipeHolder<?>> byTypeCopy = ImmutableMultimap.builder();
+        this.byName.values().forEach(r -> {
+            byNameCopy.put(r.id(), r);
+            byTypeCopy.put(r.value().getType(), r);
+        });
+        SawmillRecipeGenerator.process(this.byName.values(), byNameCopy, byTypeCopy);
+        this.byName = byNameCopy.build();
+        this.byType = byTypeCopy.build();
     }
-
-    @Inject(method = "apply(Ljava/util/Map;Lnet/minecraft/server/packs/resources/ResourceManager;Lnet/minecraft/util/profiling/ProfilerFiller;)V",
-            at = @At(value = "INVOKE", target = "Lcom/google/common/collect/ImmutableMultimap$Builder;build()Lcom/google/common/collect/ImmutableMultimap;",
-                    shift = At.Shift.BEFORE))
-    public void sawmill$addRecipes(Map<ResourceLocation, JsonElement> object, ResourceManager resourceManager, ProfilerFiller profiler, CallbackInfo ci,
-                                   @Share("byName") LocalRef<ImmutableMap.Builder<ResourceLocation, RecipeHolder<?>>> byName,
-                                   @Local ImmutableMultimap.Builder<RecipeType<?>, RecipeHolder<?>> byType) {
-        var oldRecipes = byName.get().build();
-
-        ImmutableMap.Builder<ResourceLocation, RecipeHolder<?>> copy = ImmutableMap.builder();
-        copy.putAll(oldRecipes);
-        byName.set(copy);
-        SawmillRecipeGenerator.process(oldRecipes.values(), byName.get(), byType);
-    }
-
 }


### PR DESCRIPTION
- bumped neo version to minimum that kubejs works
- bumped moonlight to the nearest version I could build
- added mixin debug export because mixin RecipeManager was P A I N

About the injection, I just took the L and just injected after it just finished the normal `.build` because:
- for some ungodly reason, `byName` `LocalRef` was not updating the local builder and to fix this I had to create another injection to capture the LocalRef *again* and redirect the last `.build` but that would cause more issues if I took control of that call alone

So I went the simplest way that is just reopened the values, create a new builder, update values, pass those values to sawmill processor and call `.build`.
I did time the process, and it was taking as much time as before, so no impact related to performance.